### PR TITLE
DM-6033 Add support for bibtex references

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,0 +1,15 @@
+@ARTICLE{2002A&A...395.1061G,
+   author = {{Greisen}, E.~W. and {Calabretta}, M.~R.},
+    title = "{Representations of world coordinates in FITS}",
+  journal = {A\&A},
+   eprint = {astro-ph/0207407},
+ keywords = {methods: data analysis, techniques: image processing, astronomical data bases: miscellaneous},
+     year = 2002,
+    month = dec,
+   volume = 395,
+    pages = {1061-1075},
+      doi = {10.1051/0004-6361:20021326},
+   adsurl = {http://adsabs.harvard.edu/abs/2002A\%26A...395.1061G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+

--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ Introduction
 
 LSST-DM currently uses WCSLIB_ to persist/un-persist and manipulate
 World Coordinate System (WCS) transformations. WCSLIB is based on the work by
-`Greisen & Calabretta 2002`_, which were incorporated into the `FITS WCS standard`_.
+`Greisen & Calabretta 2002`_ :cite:`2002A&A...395.1061G`, which were incorporated into the `FITS WCS standard`_.
 This standard only supports distortion models involving 7th order polynomials, which severly limits its ability to describe complex focal plane and on-sky distortions. Most previous projects have employed this, or a related FITS WCS-based library, usually with some home-built custom functionality, to manage their astrometric results.
 
 .. _WCSLIB: http://www.atnf.csiro.au/people/mcalabre/WCS/
@@ -328,6 +328,13 @@ Given the requirements, options, and caveats listed above, our recommendation is
 .. _significant overhead: https://jira.lsstcorp.org/browse/DM-5701
 .. _afw.math.warpExposure: https://github.com/lsst/afw/blob/w.2016.15/include/lsst/afw/math/warpExposure.h
 
+References
+==========
+
+.. bibliography:: bibliography.bib
+   :encoding: latex+latin
+   :style: plain
+
 .. _appendix pyast/gwcs:
 
 Appendix: PyAst/GWCS Performance Comparison
@@ -341,4 +348,5 @@ Python comparison code is shown below. This requires having recent versions of b
 
 .. literalinclude::
   _static/compare_gwcs_ast.py
+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML>=3.11
-Sphinx>=1.3.1
-documenteer==0.1.0
--e git://github.com/lsst-sqre/lsst_dd_rtd_theme.git@master#egg=lsst_dd_rtd_theme
+Sphinx==1.4.1
+documenteer==0.1.1
+lsst-dd-rtd-theme==0.1.0


### PR DESCRIPTION
Adds a bibliography.bib file that is just a plain bibtex file. Get content for this file from ADS.

Note that ADS forgets to escape some percents, such as the one in the adsurl. If you get a compilation error, check for unescaped characters.

This currently uses a numerical reference marker format, e.g. [1]. Natbib isn't available to us (yet).

Citations are made in the text with a 

```
:cite:`bib key`
```

format.

I've included a sample citation; I'll allow you to do the rest.

Note that you'll need to upgrade your dependencies:

```
pip install -U documenteer==0.1.1
pip install -U lsst-dd-rtd-theme==0.1.0
```
